### PR TITLE
Merging changes from support case

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 ## Assumptions
 This repository assumes that you plan to deploy an external registry, where you will sign all container images in the registry with your own GPG key.  This may be used for an offline installation, where this registry holds all of the necessary containers images for installation.  Alternatively, it may be simply used for custom images.
 
+Additionally, this repo assumes that the registry server is used as the control node.  This, of course, can easily be changed, but that is how the roles are currently written.  
+
 ## How to deploy
 Verify vars are correct by overridding them or changing the default values.  I.e. change the domain name for the registry. Registry must also be defined in the ansible hosts file.
 

--- a/README.md
+++ b/README.md
@@ -80,30 +80,30 @@ If the cluster is online, the following commands will setup policies for online 
 
 docker.io:
 ```sh
-atomic --assumeyes trust add docker.io --type insecureAcceptAnything
+ansible nodes -m command -a "atomic --assumeyes trust add docker.io --type insecureAcceptAnything"
 ```
 registry.access.redhat.com:
 ```sh
-atomic --assumeyes trust add --sigstoretype web \
+ansible nodes -m command -a "atomic --assumeyes trust add --sigstoretype web \
 --sigstore https://access.redhat.com/webassets/docker/content/sigstore \
---pubkeys /etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release registry.access.redhat.com
+--pubkeys /etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release registry.access.redhat.com"
 ```
 registry.redhat.io:
 ```sh
-atomic --assumeyes trust add --sigstoretype web \
+ansible nodes -m command -a "atomic --assumeyes trust add --sigstoretype web \
 --sigstore https://access.redhat.com/webassets/docker/content/sigstore \
---pubkeys /etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release registry.redhat.io
+--pubkeys /etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release registry.redhat.io"
 ```
 
 #### Override Default Policy
 This may be helpful if you are troubleshooting or need to pull in something that is not signed to do some local testing on a host.
 
 ```sh
-atomic --assumeyes trust default accept
+ansible nodes -m command -a "atomic --assumeyes trust default accept"
 ```
 
 The same command can be used, swapping `accept` for `reject`, to reaplly the default reject policy.
 
 ```sh
-atomic --assumeyes trust default reject
+ansible nodes -m command -a "atomic --assumeyes trust default reject"
 ```

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ curl -X GET http://registry.example.com:5000/v2/rhscl/postgresql-96-rhel7/tags/l
 ```
 
 ### Use scopeo to copy signed image to registry
+Since we have configured generated and stored the private key in root's keyring, we will need to run this as root or use `sudo`.
 ```sh
 skopeo copy --sign-by testing@example.com --src-tls-verify=false --dest-tls-verify=false \
 docker://registry.example.com:5000/rhscl/postgresql-96-rhel7:1-32 \
@@ -76,15 +77,33 @@ docker rmi $(docker images --filter "dangling=true" -q --no-trunc)
 
 ### Policies for online registries
 If the cluster is online, the following commands will setup policies for online registries.  The Red Hat registries can be configured for signature verification.
+
+docker.io:
 ```sh
-## policy for docker.io
 atomic --assumeyes trust add docker.io --type insecureAcceptAnything
-## policy for registry.access.redhat.com
+```
+registry.access.redhat.com:
+```sh
 atomic --assumeyes trust add --sigstoretype web \
 --sigstore https://access.redhat.com/webassets/docker/content/sigstore \
 --pubkeys /etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release registry.access.redhat.com
-## policy for registry.redhat.io
+```
+registry.redhat.io:
+```sh
 atomic --assumeyes trust add --sigstoretype web \
 --sigstore https://access.redhat.com/webassets/docker/content/sigstore \
 --pubkeys /etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release registry.redhat.io
+```
+
+#### Override Default Policy
+This may be helpful if you are troubleshooting or need to pull in something that is not signed to do some local testing on a host.
+
+```sh
+atomic --assumeyes trust default accept
+```
+
+The same command can be used, swapping `accept` for `reject`, to reaplly the default reject policy.
+
+```sh
+atomic --assumeyes trust default reject
 ```

--- a/README.md
+++ b/README.md
@@ -7,6 +7,11 @@ Additionally, this repo assumes that the registry server is used as the control 
 ## How to deploy
 Verify vars are correct by overridding them or changing the default values.  I.e. change the domain name for the registry. Registry must also be defined in the ansible hosts file.
 
+Pull down the code.
+```sh
+git clone -b $BRANCH https://github.com/chopskxw/openshift-container-signing.git [$WORKING_DIR]
+```
+
 Then run the playbook as follows, or as appropriate for your environment.
 ```sh
 ansible-playbook openshift-container-signing.yml
@@ -28,6 +33,12 @@ curl -X GET http://registry.example.com:5000/v2/rhscl/postgresql-96-rhel7/tags/l
 skopeo copy --sign-by testing@example.com --src-tls-verify=false --dest-tls-verify=false \
 docker://registry.example.com:5000/rhscl/postgresql-96-rhel7:1-32 \
 docker://registry.example.com:5000/rhscl/postgresql-96-rhel7:signed
+```
+Or, if pulling from Red Hat.
+```sh
+skopeo copy --remove-signatures --sign-by testing@example.com --dest-tls-verify=false \
+docker://registry.redhat.io/rhel7/etcd \
+docker://registry.williamscomplex.local:5000/signed/etcd
 ```
 
 ### Verify image digest matches

--- a/openshift_container_signing_nodes/tasks/main.yml
+++ b/openshift_container_signing_nodes/tasks/main.yml
@@ -18,22 +18,28 @@
   register: gpg_key_exists
   ignore_errors: True
 
+- name: Ensure pubkey directory exists
+  file:
+    path: /etc/pki/containers
+    state: directory
+    mode: '0755'
+
 - name: Copy signed key
   copy:
-    src: "/root/{{ signer_key_pub }}"
-    dest: "/root/{{ signer_key_pub }}"
+    src: "/etc/pki/containers/{{ signer_key_pub }}"
+    dest: "/etc/pki/containers/{{ signer_key_pub }}"
     owner: root
     group: root
   when: (create_demo_key == true) and (gpg_key_exists is failed)
 
 - name: Import signed key
-  command: "gpg2 --import /root/{{ signer_key_pub }}"
+  command: "gpg2 --import /etc/pki/containers/{{ signer_key_pub }}"
   when: (create_demo_key == true) and (gpg_key_exists is failed)
 
 - name: Add container signature store to "/etc/containers/registries.d/"
   template:
     src: registry.yaml.j2
-    dest: "/etc/containers/registries.d/registry.yaml"
+    dest: "/etc/containers/registries.d/{{ docker_registry_server }}.yaml"
     owner: root
     group: root
     mode: 0644

--- a/openshift_container_signing_nodes/templates/policy.json.j2
+++ b/openshift_container_signing_nodes/templates/policy.json.j2
@@ -15,7 +15,7 @@
         {
           "type": "signedBy",
           "keyType": "GPGKeys",
-          "keyPath": "/root/.gnupg/pubring.gpg"
+          "keyPath": "/etc/pki/containers/{{ signer_key_pub }}"
         }
       ]
     }

--- a/openshift_container_signing_registry/tasks/main.yml
+++ b/openshift_container_signing_registry/tasks/main.yml
@@ -28,8 +28,14 @@
   command: "gpg --batch --gen-key /root/testing.keyfile"
   when: (create_demo_key == true) and (gpg_key_exists is failed)
 
+- name: Ensure pubkey directory exists
+  file:
+    path: /etc/pki/containers
+    state: directory
+    mode: '0755'
+
 - name: Export signer key to file
-  command: "gpg --output /root/{{ signer_key_pub }} --armor --export testing@example.com"
+  command: "gpg --output /etc/pki/containers/{{ signer_key_pub }} --armor --export testing@example.com"
   when: (create_demo_key == true) and (gpg_key_exists is failed)
 
 - name: Ensure httpd is installed

--- a/openshift_container_signing_registry/templates/testing.keyfile.j2
+++ b/openshift_container_signing_registry/templates/testing.keyfile.j2
@@ -1,7 +1,9 @@
 Key-Type: RSA
 Key-Length: 2048
+Key-Usage: sign
 Subkey-Type: RSA
 Subkey-Length: 2048
+Subkey-Usage: encrypt
 Name-Real: Testing Key
 Name-Email: testing@example.com
 Name-Comment: non-production use only


### PR DESCRIPTION
Merging changes from support case 02383434.  These changes include moving the public keys to `/etc/pki/containers`, modification to the keyfile used to generate the signing keys, and documentation updates.